### PR TITLE
Changes to build and pass tests against Haskell platform 2013.2

### DIFF
--- a/bin/udp.hs
+++ b/bin/udp.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.STM.TMVar
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
-import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy.Builder as Builder
 
 import System.Environment (getArgs)
 import System.Random (randomRIO)
@@ -111,8 +111,8 @@ handleCommand s c = case c of
         Timer.reset (psHeartbeatTimer s) a
         return s
     CLog b -> do
-        let m = LBS8.unpack $ Builder.toLazyByteString b
-        putStrLn $ "Log: " ++ m
+        let m = BS8.unpack b
+        putStrLn $ "Log: " ++ (show m)
         return s
     CTruncateLog i -> do
         putStrLn $ "Truncate: " ++ show i

--- a/kontiki.cabal
+++ b/kontiki.cabal
@@ -26,9 +26,9 @@ Library
                      , Network.Kontiki.Raft.Utils
   Build-Depends:       base >= 4 && < 5
                      , mtl
-                     , bytestring >= 0.10.2
+                     , bytestring
                      , containers
-                     , binary
+                     , binary >= 0.7.1
                      , lens
                      , QuickCheck
   Hs-Source-Dirs:      src
@@ -57,7 +57,7 @@ Executable kontiki-udp
                      , containers
                      , random
                      , network
-                     , binary
+                     , binary >= 0.7.1
                      , conduit
                      , network-conduit
                      , rolling-queue
@@ -71,7 +71,7 @@ Test-Suite kontiki-test
   Main-Is:             test.hs
   Build-Depends:       base >= 4 && < 5
                      , mtl
-                     , binary
+                     , binary >= 0.7.1
                      , test-framework
                      , test-framework-quickcheck2
                      , kontiki

--- a/src/Network/Kontiki/Monad.hs
+++ b/src/Network/Kontiki/Monad.hs
@@ -12,7 +12,8 @@ import Control.Applicative
 import Control.Monad.RWS
 
 import Data.ByteString (ByteString)
-import Data.ByteString.Builder (Builder, byteString)
+import Data.ByteString.Lazy (toStrict)
+import Data.ByteString.Lazy.Builder (Builder, byteString,toLazyByteString)
 
 import Control.Lens hiding (Index)
 
@@ -54,7 +55,7 @@ resetHeartbeatTimeout = do
     tell [CResetHeartbeatTimeout t]
 
 log :: Monad m => Builder -> TransitionT a f m ()
-log b = tell [CLog b]
+log b = tell [CLog $ toStrict $ toLazyByteString $ b]
 
 logS :: Monad m => ByteString -> TransitionT a f m ()
 logS = log . byteString

--- a/src/Network/Kontiki/Types.hs
+++ b/src/Network/Kontiki/Types.hs
@@ -44,7 +44,8 @@ import qualified Data.Set as Set
 import Data.Word
 
 import Data.ByteString (ByteString)
-import Data.ByteString.Builder (Builder, byteString)
+import Data.ByteString.Lazy (toStrict)
+import Data.ByteString.Lazy.Builder (byteString,toLazyByteString)
 import qualified Data.ByteString.Char8 as BS8
 
 import Data.Binary (Binary(get, put))
@@ -336,7 +337,7 @@ data Command a = CBroadcast (Message a)        -- ^ Broadcast a `Message' to all
                | CSend NodeId (Message a)      -- ^ Send a `Message' to some given node
                | CResetElectionTimeout Int Int -- ^ Reset the election timeout timer to some random value in the given interval
                | CResetHeartbeatTimeout Int    -- ^ Reset the heartbeat timeout timer to the given time
-               | CLog Builder                  -- ^ Log a message
+               | CLog ByteString
                | CTruncateLog Index            -- ^ Truncate the log to given `Index'
                | CLogEntries [Entry a]         -- ^ Append some entries to the log
   deriving (Show)
@@ -355,7 +356,7 @@ instance Arbitrary a => Arbitrary (Command a) where
                  , CSend n m
                  , CResetElectionTimeout l l'
                  , CResetHeartbeatTimeout l
-                 , CLog $ byteString n
+                 , CLog $ toStrict $ toLazyByteString $ byteString n
                  , CTruncateLog i
                  , CLogEntries es
                  ]


### PR DESCRIPTION
Not sure if these changes are too radical, as they do replace Builder with strict ByteString in the CLog constructor. Nevertheless, building on Haskell Platform might help this code find wider use.

Built and tested using cabal-dev --enable-tests install.  Biggest change was dropping the version restriction on bytestring, and adding one on binary. A consequence of that change is that the CLog constructor now takes a strict ByteString, rather than a Builder.

Tested on OS X Mountain Lion with Haskell Platform 2013.2.

Tested on Ubuntu 12.04 x86-x64 using GHC 7.6.3 and Cabal 1.16.0.2, as no actual Haskell Platform build was available.
