### PR TITLE
Require network-conduit-1.0.4

### DIFF
--- a/kontiki.cabal
+++ b/kontiki.cabal
@@ -63,7 +63,7 @@ Executable kontiki-udp
                      , network
                      , binary
                      , conduit
-                     , network-conduit
+                     , network-conduit == 1.0.4
                      , rolling-queue
                      , lens
                      , kontiki


### PR DESCRIPTION
network-conduit-1.1.0 is empty (deprecated for conduit-extra). Pinning network-conduit-1.0.4, the last release, fixes this problem.
