### PR TITLE
Build on Stack(age)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,1 @@
-dist
-cabal-dev
-*.o
-*.hi
-*.chi
-*.chs.h
-.virthualenv
-.dist-buildwrapper
-.project
-.settings
-.cabal-sandbox
-cabal.sandbox.config
-TAGS
+.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,70 +7,33 @@
 # release of a major GHC version. Setting HPVER implictly sets
 # GHCVER. Omit lines with versions you don't need/want testing for.
 env:
- - GHCVER=7.6.1
- - GHCVER=7.6.2
- - GHCVER=7.6.3
- - GHCVER=head
- - HPVER=2013.2.0.0
- - HPVER=2012.4.0.0
+ - GHCVER=7.10.2
 
-matrix:
-  allow_failures:
-   - env: GHCVER=head
-
-# Note: the distinction between `before_install` and `install` is not
-#       important.
 before_install:
- - case "$HPVER" in
-    "") ;;
-
-    "2013.2.0.0")
-      export GHCVER=7.6.3 ;
-      echo "constraints:async==2.0.1.4,attoparsec==0.10.4.0,case-insensitive==1.0.0.1,cgi==3001.1.7.5,fgl==5.4.2.4,GLUT==2.4.0.0,GLURaw==1.3.0.0,haskell-src==1.0.1.5,hashable==1.1.2.5,html==1.0.1.2,HTTP==4000.2.8,HUnit==1.2.5.2,mtl==2.1.2,network==2.4.1.2,OpenGL==2.8.0.0,OpenGLRaw==1.3.0.0,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.6,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.2,stm==2.4.2,syb==0.4.0,text==0.11.3.1,transformers==0.3.0.0,unordered-containers==0.2.3.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.1" > cabal.config ;;
-
-    "2012.4.0.0")
-      export GHCVER=7.6.2 ;
-      echo "constraints:async==2.0.1.3,cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.5,HUnit==1.2.5.1,mtl==2.1.2,network==2.3.1.0,OpenGL==2.2.3.1,parallel==3.2.0.3,parsec==3.1.3,QuickCheck==2.5.1.1,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.2,split==0.2.1.1,stm==2.4,syb==0.3.7,text==0.11.2.3,transformers==0.3.0.0,vector==0.10.0.1,xhtml==3000.2.1,zlib==0.5.4.0" > cabal.config ;;
-
-    "2012.2.0.0")
-      export GHCVER=7.4.1 ;
-      echo "constraints:cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.5,html==1.0.1.2,HTTP==4000.2.3,HUnit==1.2.4.2,mtl==2.1.1,network==2.3.0.13,OpenGL==2.2.3.1,parallel==3.2.0.2,parsec==3.1.2,QuickCheck==2.4.2,random==1.0.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.1,stm==2.3,syb==0.3.6.1,text==0.11.2.0,transformers==0.3.0.0,xhtml==3000.2.1,zlib==0.5.3.3" > cabal.config ;;
-
-    "2011.4.0.0")
-      export GHCVER=7.0.4 ;
-      echo "constraints:cgi==3001.1.7.4,fgl==5.4.2.4,GLUT==2.1.2.1,haskell-src==1.0.1.4,html==1.0.1.2,HUnit==1.2.4.2,network==2.3.0.5,OpenGL==2.2.3.0,parallel==3.1.0.1,parsec==3.1.1,QuickCheck==2.4.1.1,regex-base==0.93.2,regex-compat==0.95.1,regex-posix==0.95.1,stm==2.2.0.1,syb==0.3.3,xhtml==3000.2.0.4,zlib==0.5.3.1,HTTP==4000.1.2,deepseq==1.1.0.2" > cabal.config ;;
-
-    *)
-      export GHCVER=unknown ;
-      echo "unknown/invalid Haskell Platform requested" ;
-      exit 1 ;;
-
-   esac
-
  - sudo add-apt-repository -y ppa:hvr/ghc
  - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 ghc-$GHCVER
+ - sudo apt-get install cabal-install-1.22 ghc-$GHCVER
  - export PATH=/opt/ghc/$GHCVER/bin:$PATH
 
 install:
- - cabal-1.18 update
- - cabal-1.18 install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal-1.22 update
+ - cabal-1.22 install --only-dependencies --enable-tests --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under
 # test; any command which exits with a non-zero exit code causes the
 # build to fail.
 script:
  # -v2 provides useful information for debugging
- - cabal-1.18 configure --enable-tests --enable-benchmarks -v2
+ - cabal-1.22 configure --enable-tests --enable-benchmarks -v2
 
  # this builds all libraries and executables
  # (including tests/benchmarks)
- - cabal-1.18 build
+ - cabal-1.22 build
 
- - cabal-1.18 test
- - cabal-1.18 check
+ - cabal-1.22 test
+ - cabal-1.22 check
 
  # tests that a source-distribution can be generated
- - cabal-1.18 sdist
+ - cabal-1.22 sdist
 
 # EOF

--- a/README.md
+++ b/README.md
@@ -1,59 +1,25 @@
-kontiki
+Kontiki
 =======
-
-An implementation of the Raft consensus protocol. Please check 
+An implementation of the Raft consensus protocol. See the
 [original paper](https://ramcloud.stanford.edu/wiki/download/attachments/11370504/raft.pdf)
-for details of the protocol
+for details about the protocol.
 
 [![Build Status](https://travis-ci.org/NicolasT/kontiki.png?branch=master)](https://travis-ci.org/NicolasT/kontiki)
 
 Hacking
 -------
+This project is developed using [stack](https://github.com/commercialhaskell/stack), based on an LTS snapshot of [Stackage](http://www.stackage.org). See the `stack.yaml` file for more details.
 
-This project is built using [cabal](http://www.haskell.org/cabal/). It is recommended
-that you use *cabal >= 1.18* as it introduces an excellent sandboxing capability
-which deprecates [cabal-dev](http://hackage.haskell.org/package/cabal-dev).
+Plain `cabal` can be used as well.
 
 ### Building
+Simply run `stack build --pedantic`.
 
-If you use the *cabal sandboxes* first run:
-``` bash
-$ cabal sandbox init
-```
-
-This will initialize an empty sandbox under *.cabal-sandbox*. From this point forward,
-all dependencies will be installed locally into the sandbox and will not affect your
-globally installed packages.
-
-First install all the required dependencies:
-``` bash
-$ cabal install --only-dependencies --enable-tests --enable-benchmarks --enable-library-coverage
-```
-
-Then you'll need to run the __configure__ command:
-``` bash
-$ cabal configure --enable-tests --enable-benchmarks --enable-library-coverage
-```
-
-After that you should be able to build and run the tests:
-
-``` bash
-$ cabal build && cabal test
-``` 
-
-### Code coverage
-
-Running __cabal test__ with __--enable-library-coverage__ should write
-the test coverage report under __dist/hpc__.
+### Tests
+Run `stack build --test` to run the test-suite.
 
 ### Haddock
-
-Simply run:
-``` bash
-$ cabal haddock
-```
-
-This should generate the documentation under __dist/doc__.
+Run `stack build --haddock` to build the Haddock-rendered API documentation.
 
 ### Available demos
 
@@ -65,12 +31,12 @@ This is a demo of an in-memory __kontiki__ cluster running with the use
 of [conduit](http://hackage.haskell.org/package/conduit). You can run up to 3 nodes
 and you will be able to see the logs output by them.
 
-Simply run the following in separate terminals (once you have built the udp demo executable):
+Simply run the following in separate terminals
 ``` bash
-$ kontiki-udp <nodeid>
+$ stack exec kontiki-udp <nodeid>
 ```
 
-Where *nodeid = ["node0", "node1", "node2", "node3"]*. You should be able to follow 
+where *nodeid = ["node0", "node1", "node2"]*. You should be able to follow 
 the logs output by each instance.
 
 Example output:

--- a/bin/Data/Kontiki/MemLog.hs
+++ b/bin/Data/Kontiki/MemLog.hs
@@ -10,8 +10,6 @@ module Data.Kontiki.MemLog (
     , IntMap.insert
     ) where
 
-import Control.Applicative
-
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 

--- a/bin/demo.hs
+++ b/bin/demo.hs
@@ -5,8 +5,6 @@
 
 module Main (main) where
 
-import Control.Applicative
-
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 

--- a/bin/test.hs
+++ b/bin/test.hs
@@ -44,6 +44,7 @@ prop_serialization a = decode (encode a) == a
 -- A stub MonadLog which, well... has no log at all
 newtype Stub a = Stub { unStub :: Identity a }
   deriving ( Functor
+           , Applicative
            , Monad
            )
 

--- a/kontiki.cabal
+++ b/kontiki.cabal
@@ -28,44 +28,47 @@ Library
                      , Network.Kontiki.Raft.Candidate
                      , Network.Kontiki.Raft.Leader
                      , Network.Kontiki.Raft.Utils
-  Build-Depends:       base >= 4 && < 5
-                     , mtl
-                     , bytestring >= 0.10
-                     , containers
-                     , binary >= 0.6.3
-                     , lens
-                     , QuickCheck
+  Build-Depends:       base >= 4.8 && < 4.9
+                     , mtl >= 2.2 && < 2.3
+                     , bytestring >= 0.10 && < 0.11
+                     , containers >= 0.5 && < 0.6
+                     , binary >= 0.7 && < 0.8
+                     , lens >= 4.12 && < 4.13
+                     , QuickCheck >= 2.8 && < 2.9
   Hs-Source-Dirs:      src
   Ghc-Options:         -Wall -fwarn-incomplete-patterns
 
 Executable kontiki-demo
   Main-Is:             demo.hs
-  Build-Depends:       base >= 4 && < 5
+  Build-Depends:       base
                      , mtl
-                     , stm
-                     , random
+                     , stm >= 2.4 && < 2.5
+                     , random >= 1.1 && < 1.2
                      , bytestring
                      , containers
-                     , hslogger
+                     , hslogger >= 1.2 && < 1.3
                      , kontiki
   Hs-Source-Dirs:      bin
   Ghc-Options:         -Wall -fwarn-incomplete-patterns -rtsopts -threaded
 
 Executable kontiki-udp
   Main-Is:             udp.hs
-  Build-Depends:       base >= 4 && < 5
+  Other-Modules:       Control.STM.Timer
+                     , Data.Conduit.RollingQueue
+                     , Data.Kontiki.MemLog
+  Build-Depends:       base
                      , mtl
-                     , transformers
+                     , transformers > 0.4 && < 0.5
                      , bytestring
-                     , stm
+                     , stm >= 2.4 && < 2.5
                      , containers
-                     , random
-                     , network
+                     , random >= 1.1 && < 1.2
+                     , network >= 2.6 && < 2.7
                      , binary
-                     , conduit
-                     , conduit-extra
-                     , streaming-commons
-                     , rolling-queue
+                     , conduit >= 1.2 && < 1.3
+                     , conduit-extra >= 1.1 && < 1.2
+                     , streaming-commons >= 0.1 && < 0.2
+                     , rolling-queue >= 0.1 && < 0.2
                      , lens
                      , kontiki
   Hs-Source-Dirs:      bin
@@ -74,12 +77,11 @@ Executable kontiki-udp
 Test-Suite kontiki-test
   Type:                exitcode-stdio-1.0
   Main-Is:             test.hs
-  Build-Depends:       base >= 4 && < 5
+  Build-Depends:       base
                      , mtl
                      , binary
-                     , test-framework
-                     , test-framework-quickcheck2
+                     , test-framework >= 0.8 && < 0.9
+                     , test-framework-quickcheck2 >= 0.3 && < 0.4
                      , kontiki
   Hs-Source-Dirs:      bin
   Ghc-Options:         -Wall -fwarn-incomplete-patterns -rtsopts -threaded
-  Ghc-Options:         -Wall -fwarn-incomplete-patterns -rtsopts -threaded -fhpc -hpcdir dist/hpc

--- a/src/Network/Kontiki/Monad.hs
+++ b/src/Network/Kontiki/Monad.hs
@@ -19,7 +19,6 @@ module Network.Kontiki.Monad where
 
 import Prelude hiding (log)
 
-import Control.Applicative
 import Control.Monad.RWS
 
 import Data.ByteString (ByteString)

--- a/src/Network/Kontiki/Types.hs
+++ b/src/Network/Kontiki/Types.hs
@@ -56,8 +56,6 @@ module Network.Kontiki.Types (
     , AppendEntriesResponse(..)
     ) where
 
-import Control.Applicative
-
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
@@ -240,9 +238,9 @@ data Mode = MFollower
   deriving (Show, Eq)
 
 -- * Utility type aliases for all running `Mode's.
-type Follower = State MFollower
-type Candidate = State MCandidate
-type Leader = State MLeader
+type Follower = State 'MFollower
+type Candidate = State 'MCandidate
+type Leader = State 'MLeader
 
 -- | State of a node.
 data State (s :: Mode) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+packages:
+ - .
+
+resolver: lts-3.4
+
+extra-deps:
+ - rolling-queue-0.1


### PR DESCRIPTION
Add a `stack.yaml` file for Stackage LTS-3.4, and update dependency
boundaries accordingly.

Furthermore, make build pass with `--pedantic` (on GHC-7.10, which comes
with Stackage LTS 3.4). This breaks compatibility with GHC 7.8 (due to
the Monad-Applicative changes). If this needs to be restored, add CPP
stuff etc.